### PR TITLE
Fix strategy pnl function name

### DIFF
--- a/Dispersion Trading Strategy.ipynb
+++ b/Dispersion Trading Strategy.ipynb
@@ -2362,7 +2362,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def strategy_pnl():\n",
+    "def total_strategy_pnl():\n",
     "    strategy_pnl = HDFCBANK_Ret.strategy_pnl * HDFCBANK_Lot_Size * HDFCBANK_Wt + \\\n",
     "        SBIN_Ret.strategy_pnl * SBIN_Lot_Size * SBIN_Wt + \\\n",
     "        AXISBANK_Ret.strategy_pnl * AXISBANK_Lot_Size * AXISBANK_Wt + \\\n",
@@ -2391,7 +2391,7 @@
     }
    ],
    "source": [
-    "strategy_pnl().plot(figsize=(10, 5))\n",
+    "total_strategy_pnl().plot(figsize=(10, 5))\n",
     "plt.ylabel(\"Strategy PnL\")\n",
     "plt.show()"
    ]


### PR DESCRIPTION
## Summary
- fix function name conflict in Dispersion Trading Strategy notebook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68658bd573bc8327bbea393dc6370ab1